### PR TITLE
Remove wait on log and wait only via timing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,14 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.19.1</version>
                 <configuration>
-                    <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                     <images>
                         <image>
                             <alias>mysql</alias>
                             <name>mysql:5.7</name>
 
                             <run>
-                                <ports>
-                                    <port>3306:3306</port>
-                                </ports>
                                 <wait>
-                                    <log>mysqld: ready for connections</log>
-                                    <time>30000</time>
+                                    <time>20000</time>
                                 </wait>
                                 <env>
                                     <!-- set the following:
@@ -70,7 +65,7 @@
                                     </exec>
                                 </cmd>
                                 <assembly>
-                                    <targetDir>/app</targetDir>
+                                    <basedir>/app</basedir>
                                     <descriptorRef>artifact-with-dependencies</descriptorRef>
                                 </assembly>
                             </build>
@@ -78,10 +73,6 @@
                                 <links>
                                     <link>mysql:mysql</link>
                                 </links>
-
-                                <wait>
-                                    <time>3600000</time>
-                                </wait>
                             </run>
                         </image>
 

--- a/src/main/java/com/fluxxo/docker/TestJdbc.java
+++ b/src/main/java/com/fluxxo/docker/TestJdbc.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
  */
 public class TestJdbc {
     public static void main(String[] args) throws ClassNotFoundException, SQLException, InterruptedException {
-        Class.forName("com.mysql.jdbc.Driver");
+        Class.forName("com.mysql.cj.jdbc.Driver");
         // Setup the connection with the DB
         try {
             Connection connect = DriverManager


### PR DESCRIPTION
Unfortunately the mysql image creates the log entry `mysqld: ready for connections.` twice (one of the initialisation and then for the real startup). The plugin waits only for the first ocurrence, so that your second container with app starts too early (the db is not already ready).

A brute force solution is to use a timed wait (20s worked for me). One of the next plugins will provide a way to wait for a number of identical log outputs (2 in this case). See https://github.com/fabric8io/docker-maven-plugin/issues/628 for details.

However, when you write your Java application I would recommend to be more robust. E.g. if the connection is not available yet, then add some retries. Or initialise the connection lazily only when you need it. The keyword is _resilient_, so your app should not take for granted that the DB is up all the time and must be robust for this sort of (hopefully temporarily) failures. This is even more important when running on orchestration platforms like Kubernetes and OpenShift.